### PR TITLE
sdcc/src/SDCC.y: error: label at end of compound statement. 

### DIFF
--- a/sdcc/ChangeLog
+++ b/sdcc/ChangeLog
@@ -1,3 +1,7 @@
+2015-03-28 Morris aka electronoob  <github@electronoob.com>
+
+	* sdcc/src/SDCC.y: fixed compile error, 'label at end of compound statement'.
+
 2001-11-04  Michael Hope  <michaelh@juju.net.nz>
 
 	* src/z80/peeph-gbz80.def: Removed a bad sub optimisation.

--- a/sdcc/src/SDCC.y
+++ b/sdcc/src/SDCC.y
@@ -1001,11 +1001,11 @@ pointer
 		 case S_EEPROM:
 		     DCL_TYPE($3) = EEPPOINTER;
 		     break;
-		 default:
-		   // this could be just "constant" 
-		   // werror(W_PTR_TYPE_INVALID);
-		     ;
-		     break;
+		 //default:
+		 // this could be just "constant" 
+		 // werror(W_PTR_TYPE_INVALID);
+		 //;
+		 //break;
 		 }
 	     }
 	     else 


### PR DESCRIPTION
Commented out lines 1004 through to 1009 inclusive as they were superfluous.
Compiled with GCC 4.8.2.